### PR TITLE
Fix most inconsistencies between mapnik-refenrece and this.

### DIFF
--- a/1.0.0/reference.json
+++ b/1.0.0/reference.json
@@ -22,8 +22,8 @@
         "default-meaning": "Add the current symbolizer on top of other symbolizer.",
         "doc": "Composite operation. This defines how this symbolizer should behave relative to symbolizers atop or below it.",
         "type": [
-          "add",
-          "overlay"
+            "plus",
+            "src-over"
         ],
         "expression": false
       }
@@ -87,12 +87,12 @@
       },
       "comp-op": {
         "css": "line-comp-op",
-        "default-value": "overlay",
+        "default-value": "src-over",
         "default-meaning": "Add the current symbolizer on top of other symbolizer.",
         "doc": "Composite operation. This defines how this symbolizer should behave relative to symbolizers atop or below it.",
         "type": [
-          "add",
-          "overlay"
+            "plus",
+            "src-over"
         ],
         "expression": false
       },
@@ -151,8 +151,8 @@
         "default-meaning": "Add the current symbolizer on top of other symbolizer.",
         "doc": "Composite operation. This defines how this symbolizer should behave relative to symbolizers atop or below it.",
         "type": [
-          "add",
-          "overlay"
+            "plus",
+            "src-over"
         ],
         "expression": false
       },

--- a/1.0.0/reference.json
+++ b/1.0.0/reference.json
@@ -13,7 +13,6 @@
         "css": "polygon-opacity",
         "type": "float",
         "doc": "The opacity of the polygon",
-        "default-value": 1,
         "default-meaning": "Color is fully opaque."
       },
       "comp-op": {
@@ -55,7 +54,6 @@
       },
       "stroke-opacity": {
         "css": "line-opacity",
-        "default-value": 1,
         "type": "float",
         "default-meaning": "opaque",
         "doc": "The opacity of a line"
@@ -109,7 +107,6 @@
       "opacity": {
         "css": "marker-opacity",
         "doc": "The overall opacity of the marker, if set, overrides both the opacity of both the fill and stroke",
-        "default-value": 1,
         "default-meaning": "The stroke-opacity and fill-opacity will be used",
         "type": "float"
       },
@@ -140,7 +137,6 @@
       "fill-opacity": {
         "css": "marker-fill-opacity",
         "doc": "The fill opacity of the marker.",
-        "default-value": 1.0,
         "expression": true,
         "default-meaning": "Color is fully opaque.",
         "type": "float"
@@ -174,7 +170,6 @@
       },
       "stroke-opacity": {
         "css": "marker-line-opacity",
-        "default-value": 1.0,
         "default-meaning": "Color is fully opaque.",
         "doc": "The opacity of a line.",
         "type": "float",
@@ -232,7 +227,6 @@
       "opacity": {
         "css": "text-opacity",
         "doc": "A number from 0 to 1 specifying the opacity for the text.",
-        "default-value": 1.0,
         "default-meaning": "Fully opaque",
         "expression": true,
         "type": "float"

--- a/1.0.0/reference.json
+++ b/1.0.0/reference.json
@@ -14,7 +14,7 @@
         "type": "float",
         "doc": "The opacity of the polygon",
         "default-value": 1,
-        "default-meaning": "opaque"
+        "default-meaning": "Color is fully opaque."
       },
       "comp-op": {
         "css": "polygon-comp-op",
@@ -22,11 +22,10 @@
         "default-meaning": "Add the current symbolizer on top of other symbolizer.",
         "doc": "Composite operation. This defines how this symbolizer should behave relative to symbolizers atop or below it.",
         "type": [
-          "multiply",
           "add",
           "overlay"
         ],
-        "expression": true
+        "expression": false
       }
     },
     "polygon-pattern": {
@@ -92,11 +91,10 @@
         "default-meaning": "Add the current symbolizer on top of other symbolizer.",
         "doc": "Composite operation. This defines how this symbolizer should behave relative to symbolizers atop or below it.",
         "type": [
-          "multiply",
           "add",
           "overlay"
         ],
-        "expression": true
+        "expression": false
       },
       "stroke-dasharray": {
         "css": "line-dasharray",
@@ -117,10 +115,11 @@
       },
       "fill": {
         "css": "marker-fill",
-        "default-value": "#FFF",
+        "default-value": "blue",
         "doc": "The color of the area of the marker.",
         "type": "color",
-        "expression": true
+        "expression": true,
+        "default-meaning": "The marker fill color is blue."
       },
       "allow-overlap": {
         "css": "marker-allow-overlap",
@@ -155,7 +154,7 @@
           "add",
           "overlay"
         ],
-        "expression": true
+        "expression": false
       },
       "stroke": {
         "css": "marker-line-color",
@@ -196,7 +195,7 @@
         "type": [
           "ellipse"
         ],
-        "expression": true,
+        "expression": false,
         "default-value": "ellipse",
         "default-meaning": "The marker shape is an ellipse.",
         "doc": "The default marker-type. If a SVG file is not given as the marker-file parameter, the renderer provides either an arrow or an ellipse (a circle if height is equal to width).",

--- a/1.0.0/reference.json
+++ b/1.0.0/reference.json
@@ -63,7 +63,6 @@
         "default-value": "miter",
         "type": [
           "miter",
-          "miter-revert",
           "round",
           "bevel"
         ],


### PR DESCRIPTION
This partially fix https://github.com/CartoDB/tangram-reference/issues/5

Blending (comp-op) is still broken.