### PR TITLE
Expression field fixed in many properties

### DIFF
--- a/1.0.0/reference.json
+++ b/1.0.0/reference.json
@@ -7,13 +7,15 @@
         "type": "color",
         "default-value": "rgba(128,128,128,1)",
         "default-meaning": "gray and fully opaque (alpha = 1), same as rgb(128,128,128)",
-        "doc": "Fill color to assign to a polygon"
+        "doc": "Fill color to assign to a polygon",
+        "expression": true
       },
       "fill-opacity": {
         "css": "polygon-opacity",
         "type": "float",
         "doc": "The opacity of the polygon",
-        "default-meaning": "Color is fully opaque."
+        "default-meaning": "Color is fully opaque.",
+        "expression": true
       },
       "comp-op": {
         "css": "polygon-comp-op",
@@ -44,19 +46,22 @@
         "default-value": "rgba(0,0,0,1)",
         "type": "color",
         "default-meaning": "black and fully opaque (alpha = 1), same as rgb(0,0,0)",
-        "doc": "The color of a drawn line"
+        "doc": "The color of a drawn line",
+        "expression": true
       },
       "stroke-width": {
         "css": "line-width",
         "default-value": 1,
         "type": "float",
-        "doc": "The width of a line in pixels"
+        "doc": "The width of a line in pixels",
+        "expression": true
       },
       "stroke-opacity": {
         "css": "line-opacity",
         "type": "float",
         "default-meaning": "opaque",
-        "doc": "The opacity of a line"
+        "doc": "The opacity of a line",
+        "expression": true
       },
       "stroke-linejoin": {
         "css": "line-join",
@@ -66,7 +71,7 @@
           "round",
           "bevel"
         ],
-        "expression": true,
+        "expression": false,
         "doc": "The behavior of lines when joining.",
         "default-meaning": "The line joins will be rendered using a miter look."
       },
@@ -78,7 +83,7 @@
           "round",
           "square"
         ],
-        "expression": true,
+        "expression": false,
         "doc": "The display of line endings.",
         "default-meaning": "The line endings will be rendered using a butt look."
       },
@@ -96,7 +101,7 @@
       "stroke-dasharray": {
         "css": "line-dasharray",
         "type": "numbers",
-        "expression": true,
+        "expression": false,
         "doc": "A pair of length values [a,b], where (a) is the dash length and (b) is the gap length respectively. More than two values are supported for more complex patterns.",
         "default-value": "none",
         "default-meaning": "The line will be drawn without dashes."
@@ -107,7 +112,8 @@
         "css": "marker-opacity",
         "doc": "The overall opacity of the marker, if set, overrides both the opacity of both the fill and stroke",
         "default-meaning": "The stroke-opacity and fill-opacity will be used",
-        "type": "float"
+        "type": "float",
+        "expression": true
       },
       "fill": {
         "css": "marker-fill",
@@ -120,7 +126,7 @@
       "allow-overlap": {
         "css": "marker-allow-overlap",
         "type": "boolean",
-        "expression": true,
+        "expression": false,
         "default-value": false,
         "doc": "Control whether overlapping markers are shown or hidden.",
         "default-meaning": "Do not allow markers to overlap with each other - overlapping markers will not be shown."
@@ -179,7 +185,7 @@
         "type": [
           "point"
         ],
-        "expression": true,
+        "expression": false,
         "default-value": "point",
         "default-meaning": "Place markers at the center point (centroid) of the geometry.",
         "doc": "Attempt to place markers on a point, in the center of a polygon, or if markers-placement:line, then multiple times along a line. 'interior' placement can be used to ensure that points placed on polygons are forced to be inside the polygon interior. The 'vertex-first' and 'vertex-last' options can be used to place markers at the first or last vertex of lines or polygons."


### PR DESCRIPTION
Many `expression` fields were absent, and others were set to `true` when Tangram actually doesn't support them.
Fixes https://github.com/CartoDB/tangram-cartocss/issues/71